### PR TITLE
Avoid "Text file busy" error after chmod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ ADD		./grafana/config.js /src/grafana/config.js
 ADD		./configure.sh /configure.sh
 ADD		./set_grafana.sh /set_grafana.sh
 ADD		./set_influxdb.sh /set_influxdb.sh
-RUN		chmod +x /*.sh && ./configure.sh
+RUN		chmod +x /*.sh && sleep 1 && ./configure.sh
 
 # Configure nginx and supervisord
 ADD		./nginx/nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
I had the problem detailed in docker/docker#9547 when building the image:

```
Step 21 : RUN chmod +x /*.sh && ./configure.sh
 ---> Running in 636c9f13df4e
/bin/sh: 1: ./configure.sh: Text file busy
INFO[0000] The command [/bin/sh -c chmod +x /*.sh && ./configure.sh] returned a non-zero code: 2 
```

By inserting a short sleep between the chmod and the execution of configure.sh, the issue was resolved.